### PR TITLE
Add checks to handle deps that are not target

### DIFF
--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -179,9 +179,10 @@ def _closure_js_library_impl(
     # which is a superset of the CSS libraries in its transitive closure.
     stylesheets = []
     for dep in deps:
-        if ClosureCssLibraryInfo in dep:
+        if type(dep) == "Target" and ClosureCssLibraryInfo in dep:
             stylesheets.append(dep.label)
-
+        elif hasattr(dep, "closure_css_library"):
+            stylesheets.append(dep.label)
     # JsChecker is a program that's run via the ClosureWorker persistent Bazel
     # worker. This program is a modded version of the Closure Compiler. It does
     # syntax checking and linting on the srcs files specified by this target, and
@@ -265,7 +266,10 @@ def _closure_js_library_impl(
     info_files = []
     for dep in deps:
         # Polymorphic rules, e.g. closure_css_library, might not provide this.
-        info = getattr(dep[ClosureJsLibraryInfo], "info", None)
+        if type(dep) == "Target":
+            info = getattr(dep[ClosureJsLibraryInfo], "info", None)
+        else:
+            info = getattr(dep, "info", None)
         if info:
             args.add("--dep", info)
             info_files.append(info)

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -152,9 +152,9 @@ def unfurl(deps, provider = ""):
     """Returns deps as well as deps exported by parent rules."""
     res = []
     for dep in deps:
-        if not provider or provider in dep:
+        if not provider or type(dep) == "Target" and provider in dep or type(dep) == "struct":
             res.append(dep)
-        if ClosureExportsInfo in dep:
+        if type(dep) == "Target" and ClosureExportsInfo in dep:
             for edep in dep[ClosureExportsInfo].exports:
                 if not provider or provider in edep:
                     res.append(edep)
@@ -176,17 +176,30 @@ def collect_js(
     js_module_roots = []
     has_closure_library = False
     for dep in deps:
-        srcs += [getattr(dep[ClosureJsLibraryInfo], "srcs", depset())]
-        ijs_files += [getattr(dep[ClosureJsLibraryInfo], "ijs_files", depset())]
-        infos += [getattr(dep[ClosureJsLibraryInfo], "infos", depset())]
-        modules += [getattr(dep[ClosureJsLibraryInfo], "modules", depset())]
-        descriptors += [getattr(dep[ClosureJsLibraryInfo], "descriptors", depset())]
-        stylesheets += [getattr(dep[ClosureJsLibraryInfo], "stylesheets", depset())]
-        js_module_roots += [getattr(dep[ClosureJsLibraryInfo], "js_module_roots", depset())]
-        has_closure_library = (
-            has_closure_library or
-            getattr(dep[ClosureJsLibraryInfo], "has_closure_library", False)
-        )
+        if type(dep) == "Target":
+            srcs += [getattr(dep[ClosureJsLibraryInfo], "srcs", depset())]
+            ijs_files += [getattr(dep[ClosureJsLibraryInfo], "ijs_files", depset())]
+            infos += [getattr(dep[ClosureJsLibraryInfo], "infos", depset())]
+            modules += [getattr(dep[ClosureJsLibraryInfo], "modules", depset())]
+            descriptors += [getattr(dep[ClosureJsLibraryInfo], "descriptors", depset())]
+            stylesheets += [getattr(dep[ClosureJsLibraryInfo], "stylesheets", depset())]
+            js_module_roots += [getattr(dep[ClosureJsLibraryInfo], "js_module_roots", depset())]
+            has_closure_library = (
+                has_closure_library or
+                getattr(dep[ClosureJsLibraryInfo], "has_closure_library", False)
+            )
+        else:
+            srcs += [getattr(dep, "srcs", depset())]
+            ijs_files += [getattr(dep, "ijs_files", depset())]
+            infos += [getattr(dep, "infos", depset())]
+            modules += [getattr(dep, "modules", depset())]
+            descriptors += [getattr(dep, "descriptors", depset())]
+            stylesheets += [getattr(dep, "stylesheets", depset())]
+            js_module_roots += [getattr(dep, "js_module_roots", depset())]
+            has_closure_library = (
+                has_closure_library or
+                getattr(dep, "has_closure_library", False)
+            )
     if no_closure_library:
         if has_closure_library:
             fail("no_closure_library can't be used when Closure Library is " +


### PR DESCRIPTION
In  [create_closure_js_library](
https://github.com/google/j2cl/blob/231f6489a1e4493709fb68d003316237a7c7bf3e/build_defs/internal_do_not_use/j2cl_js_common.bzl#L37) not all deps are target. here some of the deps
https://paste.googleplex.com/6020455913226240, some deps contains `info` for jsinfo. 

The [providers](https://bazel.build/extending/rules#providers) of a rule target can be accessed by type using index notation (target[DefaultInfo]). The presence of providers can be checked using the in operator (SomeInfo in target). while in operator does not work for all deps here.

